### PR TITLE
Also needs libzip

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -57,6 +57,7 @@ Build requirements:
 
 	sudo apt-get install build-essential
 	sudo apt-get install libssl-dev
+	sudo apt-get install libzip-dev
 
 for Ubuntu 12.04:
 


### PR DESCRIPTION
I was getting an error that there was no link to -lz when trying to install this on a minimal build headless Debian machine, I needed to install libzip-dev to resolve that.